### PR TITLE
refactor: useSuspenseQueries 추가

### DIFF
--- a/src/features/Drivers/useDrivers.ts
+++ b/src/features/Drivers/useDrivers.ts
@@ -1,4 +1,3 @@
-import { useSuspenseQuery } from '@tanstack/react-query'
 import axios from 'axios'
 
 export interface DriversInterface {
@@ -19,11 +18,4 @@ export interface DriversInterface {
 export const fetchDrivers = async (session_key: number): Promise<DriversInterface[]> => {
   const response = await axios.get(`https://api.openf1.org/v1/drivers?session_key=${session_key}`)
   return response.data
-}
-
-export const useFetchDrivers = (session_key: number) => {
-  return useSuspenseQuery<DriversInterface[], Error>({
-    queryKey: ['drivers', session_key],
-    queryFn: () => fetchDrivers(session_key),
-  })
 }

--- a/src/features/Position/usePosition.ts
+++ b/src/features/Position/usePosition.ts
@@ -1,4 +1,3 @@
-import { useQuery } from '@tanstack/react-query'
 import axios from 'axios'
 
 export interface PositionInterface {
@@ -19,12 +18,4 @@ export const fetchPosition = async ({ meeting_key, session_key }: FetchPositionP
     `https://api.openf1.org/v1/position?meeting_key=${meeting_key}&session_key=${session_key}`,
   )
   return response.data
-}
-
-export const useFetchPosition = ({ meeting_key, session_key }: FetchPositionProps) => {
-  return useQuery<PositionInterface[], Error>({
-    queryKey: ['meetings', meeting_key, session_key],
-    queryFn: () => fetchPosition({ meeting_key, session_key }),
-    enabled: !!meeting_key && !!session_key,
-  })
 }


### PR DESCRIPTION
두 API 간 waterfall 문제가 발생하여,   첫 번째 API가 완료된 후에야 두 번째 API를 호출하면서 성능 저하가 발생했고, 사용자는 잠시 동안 빈 화면이 나오는 오류를 useSuspenseQueries 이용하여 Driver, Position api 를 병렬로 처리하였습니다.