### PR TITLE
chore: distDir 삭제

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,5 @@
 // next.config.js
 const nextConfig = {
-  distDir: './dist', // Changes the build output directory to `./dist/`.
   swcMinify: true,
   compiler: {
     styledComponents: true,


### PR DESCRIPTION
Error: The file "/vercel/path0/.next/routes-manifest.json" couldn't be found. This is often caused by a misconfiguration in your project.

빌드중 오류 수정을 위해 아래 글을 보고 수정을 진행

https://github.com/vercel/next.js/discussions/47517#discussioncomment-5824394

