### PR TITLE
chore: Box component prop change, useMeeting reverse rogic change

### DIFF
--- a/src/components/Organisms/Footer/Footer.tsx
+++ b/src/components/Organisms/Footer/Footer.tsx
@@ -23,7 +23,7 @@ const IconLink = styled.a`
 export default function Footer() {
   return (
     <StyledFooter>
-      <Box display="flex" alignItems="center" justifyContent="space-between">
+      <Box display="flex" alignItems="center" justifyContent="space-between" borderRadius='0'>
         <Box display="flex" gap="32px">
           <Box>
             <Typography variant="body1">Made By</Typography>
@@ -40,7 +40,7 @@ export default function Footer() {
           </IconLink>
         </Box>
       </Box>
-      <Box display="flex">
+      <Box display="flex" borderRadius='0'>
         <Typography variant="caption3">
           F1 INFO is an unofficial project and is not associated in any way with the Formula 1 companies. F1, FORMULA
           ONE, FORMULA 1, FIA FORMULA ONE WORLD CHAMPIONSHIP, GRAND PRIX and related marks are trademarks of Formula One

--- a/src/components/Organisms/Header/Header.tsx
+++ b/src/components/Organisms/Header/Header.tsx
@@ -14,6 +14,7 @@ export default function Header() {
   return (
     <header>
       <Box
+        borderRadius="0"
         position="fixed"
         zIndex="100"
         top="0"
@@ -27,7 +28,9 @@ export default function Header() {
         backgroundColor={Colors.backgroundColor}
       >
         <div>
-          <Typography variant="h1">F1 INFO</Typography>
+          <Link href="/" passHref style={{ textDecoration: 'none' }}>
+            <Typography variant="h1">F1 INFO</Typography>
+          </Link>
         </div>
         <div>
           <NavBar>
@@ -36,11 +39,6 @@ export default function Header() {
                 Information
               </Typography>
             </Link>
-            {/* <Link href="/livesession" passHref style={{ textDecoration: 'none' }}>
-              <Typography variant="body1" color={Colors.white}>
-                LiveSession
-              </Typography>
-            </Link> */}
           </NavBar>
         </div>
       </Box>

--- a/src/components/Organisms/Meeting/Meeting.tsx
+++ b/src/components/Organisms/Meeting/Meeting.tsx
@@ -1,4 +1,5 @@
 // src/components/Organisms/Meeting/Meeting.tsx
+
 import { List, ListItem } from '../../Atoms/List/List'
 import { MeetingInterface, useFetchMeetings } from '../../../features/Meetings/useMeetings'
 import { useSliceMergeStore } from '../../../stores/useSliceMergeStore'

--- a/src/features/Meetings/useMeetings.ts
+++ b/src/features/Meetings/useMeetings.ts
@@ -18,13 +18,12 @@ export interface MeetingInterface {
 
 export const fetchMeetings = async (): Promise<MeetingInterface[]> => {
   const response = await axios.get(`https://api.openf1.org/v1/meetings?year=2024`)
-  return response.data
+  return response.data.reverse() // 서버에서 역순 정렬
 }
 
 export const useFetchMeetings = () => {
   return useSuspenseQuery<MeetingInterface[], Error>({
     queryKey: ['meetings'],
     queryFn: fetchMeetings,
-    select: (data) => data.reverse(), // 최신순으로 정렬
   })
 }


### PR DESCRIPTION
- 박스 컴포넌트 Home 에서 테두리가 borderRadius 적용으로 빨간 백그라운드가 보이는 것 수정
- useMeetings API 호출 함수 동작시 Hydration Error 가 발생하여 수정
-- Array.prototype.reverse()가 원본 배열을 변경하고,  reverse는 배열을 변형하는 뮤테이션 메서드이기 때문에 서버에서 렌더링된 데이터와 클라이언트에서 렌더링된 데이터가 다르게 되어 문제가 발생

서버에서 데이터를 정렬하여 내리는 방법으로 수정하였음.

서버에서 데이터를 정렬하여 클라이언트 로드 시점에서 추가 작업을 줄이고 성능을 최적화.
서버와 클라이언트 간 데이터 불일치 가능성을 완전히 제거.
클라이언트에서 데이터를 그대로 사용할 수 있어 코드의 유지보수가 쉬움.