### PR TITLE
chore: update useClient logic for better functionality

### DIFF
--- a/lib/registry.tsx
+++ b/lib/registry.tsx
@@ -7,8 +7,6 @@ import { useServerInsertedHTML } from 'next/navigation'
 import { ServerStyleSheet, StyleSheetManager } from 'styled-components'
 
 export default function StyledComponentsRegistry({ children }: { children: React.ReactNode }) {
-  // Only create stylesheet once with lazy initial state
-  // x-ref: https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
   const [styledComponentsStyleSheet] = useState(() => new ServerStyleSheet())
 
   useServerInsertedHTML(() => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,3 @@
-'use client'
-
 import Providers from '../util/provider'
 import '../font.css'
 import StyledComponentsRegistry from '../../lib/registry'

--- a/src/components/Organisms/Footer/Footer.tsx
+++ b/src/components/Organisms/Footer/Footer.tsx
@@ -1,4 +1,5 @@
-// components/Footer.tsx
+'use client'
+
 import React from 'react'
 import Box from '../../Atoms/Box/Box'
 import Typography from '../../Atoms/Typography/Typography'

--- a/src/components/Organisms/Header/Header.tsx
+++ b/src/components/Organisms/Header/Header.tsx
@@ -1,3 +1,4 @@
+'use client'
 import Link from 'next/link'
 import Box from '../../Atoms/Box/Box'
 import Typography from '../../Atoms/Typography/Typography'

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -1,4 +1,5 @@
-// styles/GlobalStyle.js
+'use client'
+
 import { createGlobalStyle } from 'styled-components'
 import { Colors } from './Colors'
 


### PR DESCRIPTION
use client는 해당 파일이 Client Component로 동작하도록 설정하므로, 최상단의 layout 컴포넌트가 Client Component로 지정되면, 그 하위 트리 전체도 Client Component로 처리되므로 SSR 기능 상실하여 해당 컴포넌트와 그 자식 트리는 서버에서 미리 렌더링되지 않고, 브라우저에서 렌더링되므로 SEO와 초기 로드 성능에 영향을 주어 수정하였음.